### PR TITLE
feat: parquet support

### DIFF
--- a/agents/factory.py
+++ b/agents/factory.py
@@ -6,6 +6,8 @@ from phi.model.base import Model
 from agents.csv_agent import CSVAgent
 from agents.sql_agent import SQLAgent
 from prompter import ConnectionDetails, SQLConnectionDetails, CSVConnectionDetails
+from agents.parquet_agent import ParquetAgent
+from prompter import ParquetConnectionDetails
 
 
 class AgentsFactory:
@@ -17,6 +19,8 @@ class AgentsFactory:
             return self.create_sql_agent(model, connection_details.to_connection_string())
         elif isinstance(connection_details, CSVConnectionDetails):
             return self.create_csv_agent(model, connection_details.file_path)
+        elif isinstance(connection_details, ParquetConnectionDetails):
+            return self.create_parquet_agent(model, connection_details.file_path)
         else:
             raise ValueError(f"Unsupported agent type: {model}")
 
@@ -31,6 +35,12 @@ class AgentsFactory:
     def create_csv_agent(self, model: Model, file_path: str) -> Any:
 
         return CSVAgent(
+            model=model,
+            file_path=file_path
+        )
+
+    def create_parquet_agent(self, model: Model, file_path: str) -> Any:
+        return ParquetAgent(
             model=model,
             file_path=file_path
         )

--- a/agents/parquet_agent.py
+++ b/agents/parquet_agent.py
@@ -1,0 +1,43 @@
+from phi.agent import Agent
+from phi.model.base import Model
+from phi.run.response import RunResponse
+from phi.tools.duckdb import DuckDbTools
+
+import logging
+
+# Remove existing handlers from the 'phi' logger
+phi_logger = logging.getLogger("phi")
+phi_logger.handlers.clear()  # This removes all handlers including RichHandler
+phi_logger.setLevel(logging.CRITICAL)  # Set to CRITICAL to suppress logs
+
+# Ensure 'rich' logs are also suppressed
+logging.getLogger("rich").setLevel(logging.CRITICAL)
+
+
+class ParquetAgent:
+    def __init__(self, model: Model, file_path: str):
+        self._init_agent(model, file_path)
+
+    def _init_agent(self, model, parquet_file):
+        tool = DuckDbTools()
+        table_name, _ = tool.load_local_path_to_table(parquet_file)
+        self._agent = Agent(
+            model=model,
+            markdown=False,
+            description="You are a data analyst.",
+            instructions=[
+                f"Use the table {table_name} to answer the question.",
+                "Then convert the natural language query into a duckdb SQL query.",
+                "Analyse and execute the SQL query to answer the question.",
+                "Figure the out column names to use in the query.",
+                "Don't add any additional information. Just answer the question.",
+                "If you can't answer the question, just say 'I don't know'.",
+            ],
+            tools=[tool],
+            show_tool_calls=False,
+            add_datetime_to_instructions=False,
+            debug_mode=False
+        )
+
+    def run(self, input_text: str) -> RunResponse:
+        return self._agent.run(input_text)

--- a/prompter.py
+++ b/prompter.py
@@ -1,7 +1,7 @@
 import functools
 import json
 import tempfile
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Tuple, Union, Dict, List, Any, Type
 
@@ -28,10 +28,10 @@ class SQLConnectionDetails:
     def to_connection_string(self) -> str:
         return f"postgresql://{self.user}:{self.password}@{self.host}:{self.port}/{self.database}"
 
-
 @dataclass
-class CSVConnectionDetails:
+class FileConnectionDetails:
     file_path: str
+    suffix: str
 
     def __post_init__(self):
 
@@ -64,7 +64,7 @@ class CSVConnectionDetails:
                         total_size = int(response.headers.get('content-length', 0))
                         task = progress.add_task(description="Downloading..", total=total_size or 1)
 
-                        with tempfile.NamedTemporaryFile(delete=False, suffix=".csv") as temp_file:
+                        with tempfile.NamedTemporaryFile(delete=False, suffix=self.suffix) as temp_file:
                             for chunk in response.iter_bytes(chunk_size=1024):
                                 temp_file.write(chunk)
                                 progress.update(task, advance=len(chunk))
@@ -81,9 +81,16 @@ class CSVConnectionDetails:
 
             raise typer.Exit()
 
+@dataclass
+class ParquetConnectionDetails(FileConnectionDetails):
+    suffix: str = field(init=False, default=".parquet")
+
+@dataclass
+class CSVConnectionDetails(FileConnectionDetails):
+    suffix: str = field(init=False, default=".csv")
 
 # TODO: Explore Python's Protocol to enforce a common interface for connection details
-ConnectionDetails = Union[SQLConnectionDetails, CSVConnectionDetails]
+ConnectionDetails = Union[SQLConnectionDetails, CSVConnectionDetails, ParquetConnectionDetails]
 
 
 class ConnectionPrompter:
@@ -96,6 +103,8 @@ class ConnectionPrompter:
             return self.get_sql_connection_details()
         elif source_type == "csv":
             return self.get_csv_file_path()
+        elif source_type == "parquet":
+            return self.get_parquet_file_path()
         else:
             raise ValueError(f"Unsupported data source type: {source_type}")
 
@@ -115,6 +124,11 @@ class ConnectionPrompter:
             file_path=Prompt.ask("[blue]Enter the path to the CSV file[/]")
         )
 
+    def get_parquet_file_path(self) -> ParquetConnectionDetails:
+        return ParquetConnectionDetails(
+            file_path=Prompt.ask("[blue]Enter the path to the parquet file[/]")
+        )
+
 
 class DataSourcePrompter:
     """
@@ -124,7 +138,7 @@ class DataSourcePrompter:
     def prompt(self) -> str:
         data_source_type = inquirer.select(
             message="Select data source type:",
-            choices=["SQL", "CSV"],
+            choices=["SQL", "CSV", "parquet"],
             default="SQL",
 
         ).execute()

--- a/prompter.py
+++ b/prompter.py
@@ -3,7 +3,7 @@ import json
 import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Tuple, Union, Dict, List, Any, Type
+from typing import Tuple, Union, Dict, List
 
 import httpx
 import typer
@@ -31,7 +31,7 @@ class SQLConnectionDetails:
 @dataclass
 class FileConnectionDetails:
     file_path: str
-    suffix: str
+    extension: str
 
     def __post_init__(self):
 
@@ -64,7 +64,7 @@ class FileConnectionDetails:
                         total_size = int(response.headers.get('content-length', 0))
                         task = progress.add_task(description="Downloading..", total=total_size or 1)
 
-                        with tempfile.NamedTemporaryFile(delete=False, suffix=self.suffix) as temp_file:
+                        with tempfile.NamedTemporaryFile(delete=False, suffix=self.extension) as temp_file:
                             for chunk in response.iter_bytes(chunk_size=1024):
                                 temp_file.write(chunk)
                                 progress.update(task, advance=len(chunk))
@@ -83,11 +83,11 @@ class FileConnectionDetails:
 
 @dataclass
 class ParquetConnectionDetails(FileConnectionDetails):
-    suffix: str = field(init=False, default=".parquet")
+    extension: str = field(init=False, default=".parquet")
 
 @dataclass
 class CSVConnectionDetails(FileConnectionDetails):
-    suffix: str = field(init=False, default=".csv")
+    extension: str = field(init=False, default=".csv")
 
 # TODO: Explore Python's Protocol to enforce a common interface for connection details
 ConnectionDetails = Union[SQLConnectionDetails, CSVConnectionDetails, ParquetConnectionDetails]
@@ -138,7 +138,7 @@ class DataSourcePrompter:
     def prompt(self) -> str:
         data_source_type = inquirer.select(
             message="Select data source type:",
-            choices=["SQL", "CSV", "parquet"],
+            choices=["SQL", "CSV", "PARQUET"],
             default="SQL",
 
         ).execute()


### PR DESCRIPTION
I've added support for parquet files.

I've used duckdb tools from phidata for it.

I've also tested with the following file: https://github.com/Ninad-Bhangui/sample-files/raw/refs/heads/main/sample_data.parquet

The data is as below:
![image](https://github.com/user-attachments/assets/8e575dac-f315-4c8d-9246-0273bb04dee8)

I tested it as shown below:
![image](https://github.com/user-attachments/assets/a65c8939-fd51-42b7-bde8-f9a917309b14)

I also changed CSVConnectionDetails to FileConnectionDetails because everything that happens in that can be applied to any file format. I inherited that into CSVConnectionDetails and ParquetConnectionDetails with a different suffix attribute for each.
